### PR TITLE
[FIX] reset detect objects on camera switch to prevent stale state

### DIFF
--- a/src/api/repository/mediaSvr.ts
+++ b/src/api/repository/mediaSvr.ts
@@ -196,7 +196,7 @@ export interface DetectsResponse {
 
 export interface CameraDetectObjectsResponse {
     camera_id: string;
-    detect_objects: string[];
+    detect_objects?: string[] | null;
 }
 
 export interface CameraDetectObjectsUpdateRequest {

--- a/src/components/side/Camera/cameraPage.tsx
+++ b/src/components/side/Camera/cameraPage.tsx
@@ -163,14 +163,16 @@ export const CameraPage = ({ mode = 'edit', pCode }: CameraPageProps) => {
     }, []);
 
     const fetchCameraDetectObjects = useCallback(async () => {
-        if (!pCode?.[E_CAMERA.KEY]) return;
+        if (!pCode?.[E_CAMERA.KEY]) {
+            setDetectObjects([]);
+            return;
+        }
         try {
             const res = await getCameraDetectObjects(pCode[E_CAMERA.KEY]);
-            if (res.success && res.data?.detect_objects) {
-                setDetectObjects(res.data.detect_objects);
-            }
+            setDetectObjects(res.success ? res.data?.detect_objects ?? [] : []);
         } catch (err) {
             console.error('Failed to fetch camera detect objects:', err);
+            setDetectObjects([]);
         }
     }, [pCode]);
 
@@ -389,6 +391,8 @@ export const CameraPage = ({ mode = 'edit', pCode }: CameraPageProps) => {
 
     useEffect(() => {
         setPayload(pCode);
+        setDetectObjects(pCode?.detect_objects ?? []);
+
         // If pCode exists (edit mode), populate form fields and fetch status
         if (pCode) {
             if (pCode.table) setNewTableName(pCode.table);
@@ -396,7 +400,6 @@ export const CameraPage = ({ mode = 'edit', pCode }: CameraPageProps) => {
             if (pCode.desc) setCameraDesc(pCode.desc);
             if (pCode.rtsp_url) setRtspUrl(pCode.rtsp_url);
             if (pCode.webrtc_url) setWebrtcUrl(pCode.webrtc_url);
-            if (pCode.detect_objects) setDetectObjects(pCode.detect_objects);
             if (pCode.save_objects !== undefined) setSaveObjects(pCode.save_objects);
 
             // Populate ffmpegConfig from pCode.ffmpeg_options

--- a/src/components/side/Camera/eventsModal.tsx
+++ b/src/components/side/Camera/eventsModal.tsx
@@ -51,28 +51,28 @@ export const EventsModal = ({ isOpen, onClose, selectedCamera, editRule, ruleCou
 
     // Fetch detect objects when modal opens with camera ID
     useEffect(() => {
-        if (!isOpen || !selectedCamera) return;
+        if (!isOpen) return;
+        if (!selectedCamera) {
+            setTargets([]);
+            setAllDetectObjects([]);
+            return;
+        }
 
         const fetchDetectData = async () => {
             try {
                 const [allDetectsRes, cameraDetectsRes] = await Promise.all([getDetects(), getCameraDetectObjects(selectedCamera)]);
 
-                // Handle all detect objects for dropdown options
-                if (allDetectsRes.success && allDetectsRes.data?.detect_objects) {
-                    setAllDetectObjects(allDetectsRes.data.detect_objects);
-                }
-
-                // Handle camera detect objects for initial targets
-                if (cameraDetectsRes.success && cameraDetectsRes.data?.detect_objects) {
-                    setTargets(cameraDetectsRes.data.detect_objects);
-                }
+                setAllDetectObjects(allDetectsRes.success ? allDetectsRes.data?.detect_objects ?? [] : []);
+                setTargets(cameraDetectsRes.success ? cameraDetectsRes.data?.detect_objects ?? [] : []);
             } catch (err) {
                 console.error('Failed to fetch detect objects:', err);
+                setAllDetectObjects([]);
+                setTargets([]);
             }
         };
 
         fetchDetectData();
-    }, [isOpen, selectedCamera, isEditMode]);
+    }, [isOpen, selectedCamera]);
 
     // Initialize form data based on editRule
     useEffect(() => {


### PR DESCRIPTION
## What this PR fixes
When switching from a camera with `detect_objects` configured to a camera without it, the **Detect objects** UI kept showing stale values from the previous camera.

## Root cause
Local state in `CameraPage` / `EventsModal` was only updated when `detect_objects` was truthy.  
If the API returned `null`/`undefined` (or omitted the field), state was not reset, so old values remained.

## Changes
- `CameraPage`
- Reset `detectObjects` to `[]` when there is no selected camera ID.
- Always sync `detectObjects` with `pCode?.detect_objects ?? []` on camera change.
- Normalize fetch result to `[]` fallback and clear on fetch error.
- `EventsModal`
- Clear `targets` / `allDetectObjects` when opened without `selectedCamera`.
- Normalize detect-object responses to `[]` when missing/null and clear on fetch error.
- API type update
- Relaxed `CameraDetectObjectsResponse.detect_objects` to `string[] | null | undefined`.

## Validation
- `npm run build` passed.
- Manual verification:
1. Camera1(with detect objects) -> Camera2(without detect objects): Detect objects is cleared.
2. Camera2 -> Camera1: Camera1 values render correctly.
3. In EventsModal, switching camera does not retain previous camera targets.

## Notes
- Empty-state UI remains unchanged (existing placeholder: `Select detect objects`).

Closes https://github.com/machbase/neo/issues/1093