### PR TITLE
[FIX] guard video playback by active tab/edit mode and restore live on unlock

### DIFF
--- a/src/components/dashboard/panels/Panel.tsx
+++ b/src/components/dashboard/panels/Panel.tsx
@@ -51,6 +51,7 @@ const Panel = ({
                     <VideoPanel
                         pLoopMode={pLoopMode}
                         pType={pType}
+                        pIsActiveTab={pIsActiveTab}
                         pChartVariableId={pChartVariableId}
                         ref={videoPanelRef}
                         pPanelInfo={pPanelInfo}

--- a/src/components/dashboard/panels/video/types/video.ts
+++ b/src/components/dashboard/panels/video/types/video.ts
@@ -54,6 +54,7 @@ export interface BoardTimeMinMax {
 export interface VideoPanelProps {
     pLoopMode: boolean;
     pType?: 'create' | 'edit';
+    pIsActiveTab?: boolean;
     pChartVariableId: string;
     pPanelInfo: any;
     pBoardInfo: any;

--- a/src/public-dashboard/components/panels/Panel.tsx
+++ b/src/public-dashboard/components/panels/Panel.tsx
@@ -13,6 +13,7 @@ const Panel = ({ pLoopMode, pChartVariableId, pBoardInfo, pPanelInfo, pParentWid
                 pPanelInfo?.type === 'Video' ? (
                     <VideoPanel
                         pLoopMode={pLoopMode}
+                        pIsActiveTab={pIsActiveTab}
                         pChartVariableId={pChartVariableId}
                         pPanelInfo={pPanelInfo}
                         pBoardInfo={pBoardInfo}


### PR DESCRIPTION
## What this PR fixes
When a Dashboard tab became inactive, or when a panel entered `create/edit` mode, the Video panel could continue playback in the background.

This PR enforces playback lock behavior:
- Recorded playback stops on lock.
- Live mode also stops on lock.
- On unlock, Live is restored only if it was Live before lock.
- Recorded playback remains paused after unlock (no auto-resume).

## Root cause
`VideoPanel` playback flow did not fully honor UI lock conditions:
- Active-tab state was not propagated into `VideoPanel`.
- Playback start paths (`Play`, `Live`, sync callbacks) were not guarded by lock state.
- Since inactive tabs are hidden (not unmounted), playback logic could keep running unless explicitly stopped.

## Changes
### Prop/interface
- Added `pIsActiveTab?: boolean` to `VideoPanelProps`.
- Passed `pIsActiveTab` from Dashboard Panel wrappers (including public-dashboard panel wrapper).

### Lock state + restore behavior
- Added `isPlaybackLocked = !pIsActiveTab || pType === 'create' || pType === 'edit'`.
- On lock:
- Pause recorded playback (`sync.pause()`).
- Stop Live mode if `isLive` or `isConnecting`.
- Persist a restore flag when Live was active before lock.
- On unlock:
- Restore Live only when the restore flag is set.
- Keep recorded playback paused.
- Playback entry guards

### Block playback start while locked in:
- `onSyncPlay`
- `onSyncLoop`
- `handlePlayToggle`
- `handleLiveToggle`

## Validation
- Covered scenarios:
1. Recorded playback stops when tab becomes inactive.
2. Live stops on lock and restores on unlock.
3. Entering `edit` stops recorded playback and Live.
4. Exiting `edit` restores Live if it was active before lock.
5. `Play` is blocked while locked.
6. `Live` toggle is blocked while locked.

## Notes
- This PR is scoped to playback lock/restore behavior only.
- Time-range sync semantics are unchanged.

Closes: https://github.com/machbase/neo/issues/1105