### PR TITLE
(#899) [FEAT] add row number toggle and query copy from result header icon

### DIFF
--- a/src/assets/icons/Icon.tsx
+++ b/src/assets/icons/Icon.tsx
@@ -108,6 +108,8 @@ export {
     TbSquarePlus,
     TbParachute,
     TbRowInsertTop as InsertRowTop,
+    TbListNumbers as RowNumberOn,
+    TbList as RowNumberOff,
     TbFolderPlus,
     TbFolderDown,
     TbFolder,

--- a/src/components/buttons/IconButton.scss
+++ b/src/components/buttons/IconButton.scss
@@ -38,6 +38,15 @@
     text-wrap: balance;
 }
 
+.tooltip-div-content {
+    white-space: pre-wrap;
+}
+
+.tooltip-div-footer {
+    margin-top: 6px;
+    opacity: 0.8;
+}
+
 .icon-btn-active-hover {
     background-color: transparent;
     &:hover {

--- a/src/components/buttons/IconButton.tsx
+++ b/src/components/buttons/IconButton.tsx
@@ -11,6 +11,7 @@ export interface IconButtonProps {
     pDisabled?: boolean;
     pIsToopTip?: boolean;
     pToolTipContent?: string;
+    pToolTipFooter?: string;
     pToolTipId?: string;
     pToolTipMaxWidth?: number;
     pPlace?: PlacesType | undefined;
@@ -29,6 +30,7 @@ export const IconButton = (props: IconButtonProps) => {
         pIsActiveHover = false,
         pIsToopTip,
         pToolTipContent,
+        pToolTipFooter,
         pToolTipId,
     } = props;
     const sDisabledClass = pDisabled ? 'icon-btn-disabled' : '';
@@ -57,10 +59,17 @@ export const IconButton = (props: IconButtonProps) => {
                         place={pPlace ?? 'top-end'}
                         positionStrategy="absolute"
                         anchorSelect={`.tooltip-${pToolTipId}`}
-                        content={pToolTipContent}
+                        content={!pToolTipFooter ? pToolTipContent : undefined}
                         style={{ width: pToolTipMaxWidth && pToolTipMaxWidth < 500 ? pToolTipMaxWidth + 'px' : '' }}
                         delayShow={700}
-                    />
+                    >
+                        {pToolTipFooter ? (
+                            <div className="tooltip-div-content">
+                                {pToolTipContent ? <div>{pToolTipContent}</div> : undefined}
+                                <div className="tooltip-div-footer">{pToolTipFooter}</div>
+                            </div>
+                        ) : undefined}
+                    </Tooltip>
                 </>
             ) : (
                 pIcon

--- a/src/components/sql/index.tsx
+++ b/src/components/sql/index.tsx
@@ -8,7 +8,7 @@ import { getTqlChart } from '@/api/repository/machiot';
 import { SQL_BASE_LIMIT, sqlBasicFormatter, STATEMENT_TYPE } from '@/utils/sqlFormatter';
 import { Button } from '@/design-system/components';
 import './index.scss';
-import { BarChart, AiOutlineFileDone, Save, LuFlipVertical, Play, SaveAs, Download } from '@/assets/icons/Icon';
+import { BarChart, AiOutlineFileDone, Save, LuFlipVertical, Play, SaveAs, Download, RowNumberOn, RowNumberOff } from '@/assets/icons/Icon';
 import { fixedEncodeURIComponent, isJsonString } from '@/utils/utils';
 import { PositionType, SelectionType } from '@/utils/sqlQueryParser';
 import { MonacoEditor } from '../monaco/MonacoEditor';
@@ -46,6 +46,7 @@ const Sql = ({
     const [sErrLog, setErrLog] = useState<string | null>(null);
     const [sTextField, setTextField] = useState<string>('');
     const [sMoreResult, setMoreResult] = useState<boolean>(false);
+    const [sShowRowNumber, setShowRowNumber] = useState<boolean>(true);
     const [sChartAxisList, setChartAxisList] = useState<string[]>([]);
     const [sChartQueryList, setChartQueryList] = useState<STATEMENT_TYPE[] | []>([]);
     const sSaveCommand = useRef<any>(null);
@@ -297,6 +298,16 @@ const Sql = ({
                                 <Button
                                     size="icon"
                                     variant="ghost"
+                                    isToolTip
+                                    toolTipContent={`${sShowRowNumber ? 'Hide' : 'Show'} row number`}
+                                    icon={sShowRowNumber ? <RowNumberOn size={16} /> : <RowNumberOff size={16} />}
+                                    active={sShowRowNumber}
+                                    onClick={() => setShowRowNumber((prev) => !prev)}
+                                    aria-label={`${sShowRowNumber ? 'Hide' : 'Show'} row number`}
+                                />
+                                <Button
+                                    size="icon"
+                                    variant="ghost"
                                     disabled={!sOldFetchTxt || !sSqlResponseData || (sSqlResponseData?.rows?.length === 1 && sSqlResponseData?.columns?.length === 1)}
                                     isToolTip
                                     toolTipContent="Download CSV"
@@ -340,6 +351,8 @@ const Sql = ({
                                     <RESULT
                                         pDisplay={sSelectedSubTab === 'RESULT' ? '' : 'none'}
                                         pSqlResponseData={sSqlResponseData}
+                                        pShowRowNumber={sShowRowNumber}
+                                        pExcludeRowNumberFromSelection={true}
                                         onMoreResult={() => onMoreResult()}
                                         pHelpTxt={sOldFetchTxt?.text ?? ''}
                                     />

--- a/src/components/sql/result.tsx
+++ b/src/components/sql/result.tsx
@@ -10,12 +10,14 @@ import { ClipboardCopy } from '@/utils/ClipboardCopy';
 interface ResultProps {
     pDisplay: string;
     pSqlResponseData: any;
+    pShowRowNumber: boolean;
+    pExcludeRowNumberFromSelection?: boolean;
     pMaxShowLen?: boolean;
     pHelpTxt?: string;
     onMoreResult: () => void;
 }
 
-const RESULT = ({ pDisplay, pSqlResponseData, pMaxShowLen, pHelpTxt, onMoreResult }: ResultProps) => {
+const RESULT = ({ pDisplay, pSqlResponseData, pShowRowNumber, pExcludeRowNumberFromSelection = false, pMaxShowLen, pHelpTxt, onMoreResult }: ResultProps) => {
     const [observe, unobserve] = useObserver(0, onMoreResult);
     const sObserveRef = useRef<any>(null);
     const sRootRef = useRef<any>(null);
@@ -75,6 +77,8 @@ const RESULT = ({ pDisplay, pSqlResponseData, pMaxShowLen, pHelpTxt, onMoreResul
                 pMaxShowLen={pMaxShowLen}
                 clickEvent={handleClick}
                 pHelpText={pHelpTxt}
+                pShowRowNumber={pShowRowNumber}
+                pExcludeRowNumberFromSelection={pExcludeRowNumberFromSelection}
                 pMaxWidth={sRootRef && sRootRef?.current && sRootRef?.current?.clientWidth}
             />
             <div ref={sObserveRef} style={{ width: '100%', height: '1px' }} />

--- a/src/components/table/index.tsx
+++ b/src/components/table/index.tsx
@@ -16,6 +16,8 @@ interface TableProps {
     pMaxShowLen?: boolean;
     pHelpText?: string;
     pMaxWidth?: number;
+    pShowRowNumber?: boolean;
+    pExcludeRowNumberFromSelection?: boolean;
     clickEvent?: (e: any, aRowData: string) => void;
 }
 
@@ -24,14 +26,25 @@ const TABLE = ({
     pMaxShowLen,
     pHelpText,
     pMaxWidth = 25,
+    pShowRowNumber = true,
+    pExcludeRowNumberFromSelection = false,
 }: // clickEvent
 TableProps) => {
+    const sRowNumberHeaderCellStyle = pExcludeRowNumberFromSelection ? { userSelect: 'none' as const } : undefined;
+    const sRowNumberBodyCellStyle = pExcludeRowNumberFromSelection ? { userSelect: 'none' as const, pointerEvents: 'none' as const } : undefined;
+    const handleHelpIconClick = () => {
+        if (!pHelpText) return;
+        ClipboardCopy(pHelpText);
+    };
+
     const MaxLenDiv = () => {
         return (
             <tr key="tbody-row5" className="result-body-tr">
-                <td>
-                    <span style={{ marginLeft: '20px', cursor: 'default' }}>...</span>
-                </td>
+                {pShowRowNumber ? (
+                    <td style={sRowNumberBodyCellStyle}>
+                        <span style={{ marginLeft: '20px', cursor: 'default' }}>...</span>
+                    </td>
+                ) : null}
 
                 {pTableData.columns.map((aItem: any) => {
                     return (
@@ -48,24 +61,27 @@ TableProps) => {
             <thead className="table-header header-fix">
                 {pTableData && pTableData?.columns ? (
                     <tr>
-                        <th>
-                            {pHelpText !== undefined && pHelpText ? (
-                                <IconButton
-                                    pWidth={20}
-                                    pHeight={20}
-                                    pIsActive={false}
-                                    pIsActiveHover={false}
-                                    pIsToopTip
-                                    pToolTipMaxWidth={pMaxWidth}
-                                    pToolTipContent={pHelpText}
-                                    pToolTipId="sql-result-tab"
-                                    pIcon={<div style={{ width: '16px', height: '16px', marginLeft: '32px', cursor: 'default' }}>{<PiFileSqlThin />}</div>}
-                                    onClick={() => {}}
-                                />
-                            ) : (
-                                <span style={{ marginLeft: '20px', cursor: 'default' }} />
-                            )}
-                        </th>
+                        {pShowRowNumber ? (
+                            <th style={sRowNumberHeaderCellStyle}>
+                                {pHelpText !== undefined && pHelpText ? (
+                                    <IconButton
+                                        pWidth={20}
+                                        pHeight={20}
+                                        pIsActive={false}
+                                        pIsActiveHover={false}
+                                        pIsToopTip
+                                        pToolTipMaxWidth={pMaxWidth}
+                                        pToolTipContent={pHelpText}
+                                        pToolTipFooter="Click to copy query"
+                                        pToolTipId="sql-result-tab"
+                                        pIcon={<div style={{ width: '16px', height: '16px', marginLeft: '32px', cursor: 'pointer' }}>{<PiFileSqlThin />}</div>}
+                                        onClick={handleHelpIconClick}
+                                    />
+                                ) : (
+                                    <span style={{ marginLeft: '20px', cursor: 'default' }} />
+                                )}
+                            </th>
+                        ) : null}
                         {pTableData.columns.map((aColumn: string, idx: number) => {
                             return (
                                 <th key={`${aColumn}-${idx.toString()}`} style={{ cursor: 'default' }}>
@@ -83,12 +99,14 @@ TableProps) => {
                     ? pTableData.rows.map((aRowList: any, aIdx: number) => {
                           if (!!pMaxShowLen && aIdx + 1 === 6) return MaxLenDiv();
                           if (pMaxShowLen && aIdx + 1 > 6) return <></>;
-                          if (aRowList.length === 1 && aRowList[0] === '') return;
-                          return (
-                              <tr key={'tbody-row' + aIdx} className={Number(aIdx) % 2 === 0 ? 'result-body-tr' : 'result-body-tr dark-odd'}>
-                                  <td>
-                                      <span className="row-num">{aIdx + 1}</span>
-                                  </td>
+                                  if (aRowList.length === 1 && aRowList[0] === '') return;
+                                  return (
+                                      <tr key={'tbody-row' + aIdx} className={Number(aIdx) % 2 === 0 ? 'result-body-tr' : 'result-body-tr dark-odd'}>
+                                          {pShowRowNumber ? (
+                                              <td style={sRowNumberBodyCellStyle}>
+                                                  <span className="row-num">{aIdx + 1}</span>
+                                              </td>
+                                          ) : null}
                                   {aRowList.map((aRowData: any, bIdx: number) => {
                                       return (
                                           <td className="result-table-item" key={'table-' + aIdx + '-' + bIdx}>


### PR DESCRIPTION
<img width="794" height="603" alt="image" src="https://github.com/user-attachments/assets/cf78c17e-7122-4294-9222-4288e7c1b45a" />
