### PR TITLE
refactor: standardize validated action icons

### DIFF
--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -7,7 +7,7 @@ import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { gBoardList, gRollupTableList, gSelectedTab } from '@/recoil/recoil';
 import Panel from './panels/Panel';
 import CreatePanel from './createPanel/CreatePanel';
-import { VscChevronLeft, Calendar, TbSquarePlus, VscChevronRight, Save, SaveAs, VscSync, Share } from '@/assets/icons/Icon';
+import { VscChevronLeft, Calendar, TbSquarePlus, VscChevronRight, Save, SaveAs, MdRefresh, Share } from '@/assets/icons/Icon';
 import TimeRangeModal from '../modal/TimeRangeModal';
 import moment from 'moment';
 import { calcRefreshTime, setUnitTime, formatTimeValue } from '@/utils/dashboardUtil';
@@ -249,7 +249,7 @@ const Dashboard = ({ pDragStat, pInfo, pWidth, pHandleSaveModalOpen, pSetIsSaveM
                             <Button
                                 size="icon"
                                 variant="ghost"
-                                icon={<VscSync size={16} />}
+                                icon={<MdRefresh size={16} />}
                                 isToolTip
                                 toolTipContent="Refresh"
                                 onClick={() => HandleRefresh(pInfo.dashboard.timeRange)}

--- a/src/components/inputs/SearchInput.tsx
+++ b/src/components/inputs/SearchInput.tsx
@@ -1,4 +1,4 @@
-import { Search, Cancel } from '@/assets/icons/Icon';
+import { Search, Close } from '@/assets/icons/Icon';
 import { useState, useRef, useEffect } from 'react';
 import useDebounce from '@/hooks/useDebounce';
 import './Input.scss';
@@ -41,7 +41,7 @@ export const SearchInput = (props: SearchInputProps) => {
             {pIsExpand ? (
                 <div className="custom-input-wrapper" style={{ width: pWidth + 'px', height: pHeight + 'px', display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
                     <input ref={inputRef} type={'text'} value={sValue} onChange={(e) => setValue(e.target.value)} />
-                    <Cancel onClick={handleClose} />
+                    <Close onClick={handleClose} title="Cancel search" aria-label="Cancel search" />
                 </div>
             ) : (
                 <Search onClick={() => onChangeExpand(true)} />

--- a/src/components/modal/SaveDashboardModal.tsx
+++ b/src/components/modal/SaveDashboardModal.tsx
@@ -10,7 +10,7 @@ import { getFiles as getFilesTree, deleteFile as deleteContextFile } from '@/api
 import { Menu } from '@/components/contextMenu/Menu';
 import useOutsideClick from '@/hooks/useOutsideClick';
 import { Toast } from '@/design-system/components';
-import { Home, TreeFolder, Delete, Download, Play, Search, Save, ArrowLeft, ArrowRight, NewFolder } from '@/assets/icons/Icon';
+import { Home, TreeFolder, Delete, Download, Play, Search, Save, ArrowLeft, ArrowRight, TbFolderPlus, Close } from '@/assets/icons/Icon';
 import icons from '@/utils/icons';
 import { calcInterval, CheckObjectKey, decodeFormatterFunction, setUnitTime } from '@/utils/dashboardUtil';
 import { DashboardQueryParser, SqlResDataType } from '@/utils/DashboardQueryParser';
@@ -400,7 +400,7 @@ export const SaveDashboardModal = (props: SaveDashboardModalProps) => {
                                         variant="ghost"
                                         isToolTip
                                         toolTipContent="Cancel"
-                                        icon={<Search size={14} />}
+                                        icon={<Close size={14} />}
                                         onClick={() => setIsSearchMode(!sIsSearchMode)}
                                     />
                                 }
@@ -429,7 +429,7 @@ export const SaveDashboardModal = (props: SaveDashboardModalProps) => {
                             />
                         )}
                     </div>
-                    <Button size="sm" variant="ghost" isToolTip toolTipContent="New folder" icon={<NewFolder size={16} />} onClick={makeFolder} />
+                    <Button size="sm" variant="ghost" isToolTip toolTipContent="New folder" icon={<TbFolderPlus size={16} />} onClick={makeFolder} />
                 </div>
 
                 <FileListHeader />

--- a/src/components/side/FileExplorer/SaveModal.tsx
+++ b/src/components/side/FileExplorer/SaveModal.tsx
@@ -10,7 +10,7 @@ import { Menu } from '@/components/contextMenu/Menu';
 import useOutsideClick from '@/hooks/useOutsideClick';
 import { gSaveWorkSheets } from '@/recoil/workSheet';
 import { Toast } from '@/design-system/components';
-import { Home, TreeFolder, Delete, Download, Play, Search, Save, Close, ArrowLeft, ArrowRight, NewFolder, FolderOpen } from '@/assets/icons/Icon';
+import { Home, TreeFolder, Delete, Download, Play, Search, Save, Close, ArrowLeft, ArrowRight, TbFolderPlus, FolderOpen } from '@/assets/icons/Icon';
 import icons from '@/utils/icons';
 import EnterCallback from '@/hooks/useEnter';
 import { TreeFetchDrilling } from '@/utils/UpdateTree';
@@ -475,7 +475,7 @@ export const SaveModal = (props: SaveModalProps) => {
                             />
                         )}
                     </div>
-                    <Button size="sm" variant="ghost" isToolTip toolTipContent="New folder" icon={<NewFolder size={16} />} onClick={makeFolder} />
+                    <Button size="sm" variant="ghost" isToolTip toolTipContent="New folder" icon={<TbFolderPlus size={16} />} onClick={makeFolder} />
                 </div>
 
                 <FileListHeader />

--- a/src/components/tagAnalyzer/panel/Panel.tsx
+++ b/src/components/tagAnalyzer/panel/Panel.tsx
@@ -5,7 +5,7 @@ import Chart from './Chart';
 import { useEffect, useRef, useState } from 'react';
 import { getDateRange } from '@/utils/helpers/date';
 import { fetchCalculationData, fetchRawData } from '@/api/repository/machiot';
-import { ArrowLeft, ArrowRight, Close } from '@/assets/icons/Icon';
+import { VscChevronLeft, VscChevronRight, Close } from '@/assets/icons/Icon';
 import { useRecoilValue } from 'recoil';
 import { gRollupTableList, gSelectedTab } from '@/recoil/recoil';
 import { isEmpty, isRollup } from '@/utils';
@@ -759,7 +759,7 @@ any) => {
                 pOnEditRequest={pOnEditRequest}
             />
             <div className="chart">
-                <Button size="md" variant="secondary" isToolTip toolTipContent="Move range" icon={<ArrowLeft size={16} />} onClick={() => moveTimRange('l')} />
+                <Button size="md" variant="secondary" isToolTip toolTipContent="Move range backward" icon={<VscChevronLeft size={16} />} onClick={() => moveTimRange('l')} />
                 <div className="chart-body" ref={sAreaChart}>
                     <Chart
                         pAreaChart={sAreaChart}
@@ -777,7 +777,7 @@ any) => {
                         pMinMaxList={sMinMaxList}
                     />
                 </div>
-                <Button size="md" variant="secondary" isToolTip toolTipContent="Move range" icon={<ArrowRight size={16} />} onClick={() => moveTimRange('r')} />
+                <Button size="md" variant="secondary" isToolTip toolTipContent="Move range forward" icon={<VscChevronRight size={16} />} onClick={() => moveTimRange('r')} />
             </div>
             <PanelFooter
                 pNavigatorRange={pFooterRange ?? sNavigatorRange}

--- a/src/components/tagAnalyzer/panel/PanelFooter.tsx
+++ b/src/components/tagAnalyzer/panel/PanelFooter.tsx
@@ -3,7 +3,7 @@ import ZoomInTwo from '@/assets/image/btn_zoom in x2@3x.png';
 import ZoomInFour from '@/assets/image/btn_zoom in x4@3x.png';
 import ZoomOutTwo from '@/assets/image/btn_zoom out x2@3x.png';
 import ZoomOUTFOUR from '@/assets/image/btn_zoom out x4@3x.png';
-import { ArrowLeft, ArrowRight, MdCenterFocusStrong } from '@/assets/icons/Icon';
+import { VscChevronLeft, VscChevronRight, MdCenterFocusStrong } from '@/assets/icons/Icon';
 import { changeUtcToText } from '@/utils/helpers/date';
 import { Button } from '@/design-system/components';
 const PanelFooter = ({ pSetButtonRange, pPanelInfo, pNavigatorRange, pMoveNavigatorTimRange }: any) => {
@@ -26,7 +26,7 @@ const PanelFooter = ({ pSetButtonRange, pPanelInfo, pNavigatorRange, pMoveNaviga
                 className="toolbar"
             >
                 <div className="arrow-form">
-                    <Button size="xsm" variant="ghost" isToolTip toolTipContent="Move range" icon={<ArrowLeft size={16} />} onClick={() => pMoveNavigatorTimRange('l')} />
+                    <Button size="xsm" variant="ghost" isToolTip toolTipContent="Move range backward" icon={<VscChevronLeft size={16} />} onClick={() => pMoveNavigatorTimRange('l')} />
                     <div>{pNavigatorRange.startTime && changeUtcToText(pNavigatorRange.startTime)}</div>
                 </div>
                 <Button.Group style={{ border: 'solid 0.5px #454545', borderRadius: '4px' }}>
@@ -73,7 +73,7 @@ const PanelFooter = ({ pSetButtonRange, pPanelInfo, pNavigatorRange, pMoveNaviga
                 </Button.Group>
                 <div className="arrow-form">
                     <div>{pNavigatorRange.endTime && changeUtcToText(pNavigatorRange.endTime)}</div>
-                    <Button size="xsm" variant="ghost" isToolTip toolTipContent="Move range" icon={<ArrowRight size={16} />} onClick={() => pMoveNavigatorTimRange('r')} />
+                    <Button size="xsm" variant="ghost" isToolTip toolTipContent="Move range forward" icon={<VscChevronRight size={16} />} onClick={() => pMoveNavigatorTimRange('r')} />
                 </div>
             </div>
         </div>

--- a/src/design-system/components/Combobox/index.tsx
+++ b/src/design-system/components/Combobox/index.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, ReactNode, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { MdClose } from 'react-icons/md';
 import { useCombobox, type UseComboboxProps, type UseComboboxReturn, type ComboboxOption } from '../../hooks/useCombobox';
 import useOutsideClick from '@/hooks/useOutsideClick';
 import { Button } from '../Button';
@@ -142,9 +143,7 @@ const ComboboxClear = ({ className }: ComboboxClearProps) => {
 
     return (
         <button onClick={combobox.handleClear} className={`${styles['combobox__clear']} ${className ?? ''}`} type="button" aria-label="Clear selection">
-            <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
-                <path d="M2 2L10 10M2 10L10 2" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-            </svg>
+            <MdClose size={12} />
         </button>
     );
 };

--- a/src/design-system/components/HierarchicalCombobox/index.tsx
+++ b/src/design-system/components/HierarchicalCombobox/index.tsx
@@ -1,7 +1,6 @@
 import React, { createContext, useContext, ReactNode, useState, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
-import { MdOutlineChevronRight, MdExpandMore } from 'react-icons/md';
-import { IoBackspaceOutline } from 'react-icons/io5';
+import { MdOutlineChevronRight, MdExpandMore, MdClose } from 'react-icons/md';
 import { FaCheck } from 'react-icons/fa';
 import { Button } from '../Button';
 import styles from './index.module.scss';
@@ -226,7 +225,7 @@ const HierarchicalComboboxInput = ({ className }: HierarchicalComboboxInputProps
                     type="button"
                     variant="ghost"
                     size="sm"
-                    icon={<IoBackspaceOutline size={16} />}
+                    icon={<MdClose size={16} />}
                     onClick={handleClear}
                     className={styles['hierarchical-combobox__clear']}
                     aria-label="Clear selection"

--- a/src/public-dashboard/assets/icons/Icon.tsx
+++ b/src/public-dashboard/assets/icons/Icon.tsx
@@ -3,7 +3,6 @@ export {
     VscChevronRight,
     VscChevronLeft,
     VscWarning,
-    VscSync,
     VscRecord,
 } from 'react-icons/vsc';
 
@@ -12,6 +11,7 @@ export {
     MdSave as Save,
     MdDelete as Delete,
     MdOutlineKeyboardArrowDown as ArrowDown,
+    MdRefresh,
 } from 'react-icons/md';
 
 export { BiPlay as Play } from 'react-icons/bi';

--- a/src/public-dashboard/components/Dashboard/DashboardView.tsx
+++ b/src/public-dashboard/components/Dashboard/DashboardView.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import GridLayout from 'react-grid-layout';
 import { useParams, useSearchParams } from 'react-router-dom';
 import moment from 'moment';
-import { Calendar, VscChevronLeft, VscChevronRight, VscSync } from '../../assets/icons/Icon';
+import { Calendar, VscChevronLeft, VscChevronRight, MdRefresh } from '../../assets/icons/Icon';
 import { calcRefreshTime, setUnitTime } from '../../utils/dashboardUtil';
 import { GRID_LAYOUT_COLS, GRID_LAYOUT_ROW_HEIGHT } from '../../utils/constants';
 import { getId, isMobile } from '../../utils';
@@ -292,7 +292,7 @@ const DashboardView = () => {
                     </Button.Group>
                     <div style={{ display: 'flex', alignItems: 'center' }}>
                         <Button variant="ghost" size="icon" icon={<Share size={16} />} onClick={() => setIsShareModal(true)} isToolTip toolTipContent="Share" />
-                        <Button variant="ghost" size="icon" icon={<VscSync size={16} />} onClick={handleRefresh} isToolTip toolTipContent="Refresh" />
+                        <Button variant="ghost" size="icon" icon={<MdRefresh size={16} />} onClick={handleRefresh} isToolTip toolTipContent="Refresh" />
                         <Button variant="ghost" size="icon" icon={<VscChevronLeft size={16} />} onClick={() => moveTimeRange('l')} />
                         <Button size="sm" variant="ghost" onClick={() => setIsTimeRangeModal(true)}>
                             <Calendar style={{ paddingRight: '8px' }} />

--- a/src/view/Dashboard/DashboardView.tsx
+++ b/src/view/Dashboard/DashboardView.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import GridLayout from 'react-grid-layout';
 import { useParams } from 'react-router-dom';
 import moment from 'moment';
-import { Calendar, VscChevronLeft, VscChevronRight, VscSync } from '@/assets/icons/Icon';
+import { Calendar, VscChevronLeft, VscChevronRight, MdRefresh } from '@/assets/icons/Icon';
 import { calcRefreshTime, setUnitTime } from '@/utils/dashboardUtil';
 import { GRID_LAYOUT_COLS, GRID_LAYOUT_ROW_HEIGHT } from '@/utils/constants';
 import { getId, isMobile } from '@/utils';
@@ -213,7 +213,7 @@ const DashboardView = () => {
                         )}
                     </Button.Group>
                     <div style={{ display: 'flex', alignItems: 'center' }}>
-                        <Button variant="ghost" size="icon" icon={<VscSync size={16} />} onClick={handleRefresh} isToolTip toolTipContent="Refresh" />
+                        <Button variant="ghost" size="icon" icon={<MdRefresh size={16} />} onClick={handleRefresh} isToolTip toolTipContent="Refresh" />
                         <Button variant="ghost" size="icon" icon={<VscChevronLeft size={16} />} onClick={() => moveTimeRange('l')} />
                         <Button size="sm" variant="ghost" onClick={() => setIsTimeRangeModal(true)}>
                             <Calendar style={{ paddingRight: '8px' }} />


### PR DESCRIPTION
### Refresh
같은 역할을 하는 새로고침 아이콘이 서로 다르게 적용되어 있었으며, 이를 explorer의 아이콘으로 통일하였습니다.

#### Before
![explorer](https://github.com/user-attachments/assets/41da8750-10cd-44a8-ac3d-65c6367332e1)

![dashboard](https://github.com/user-attachments/assets/ca9ac13f-3b99-4c4c-8fec-766d7e4adba3)

#### After
![dashboard](https://github.com/user-attachments/assets/2fd9422c-a914-400e-9860-7fbb12e2af6e)

### New folder
Explorer, Explorer context menu의 new foler 아이콘과 Save modal의 New folder 아이콘을 통일하였습니다.

#### Before
![](https://github.com/user-attachments/assets/a730996a-d9f2-42b5-9640-3b017cdd7bc8)

![](https://github.com/user-attachments/assets/4913476a-f5db-4493-86d1-dbb64aef4ff7)

![](https://github.com/user-attachments/assets/7e2066a3-34f5-4b53-96a5-fc4ca0fc1760)

#### After
![](https://github.com/user-attachments/assets/e80e356e-ded5-401b-a732-32167a9e656f)

이외 ArrowLeft -> VscChevronLeft, ArrowRight -> VscChevronRight로 통일, Cancel -> Close 통일이 이루어졌습니다.
